### PR TITLE
feat: add LegacyDoc AI

### DIFF
--- a/data/json/en/tools/ide.jsonc
+++ b/data/json/en/tools/ide.jsonc
@@ -66,6 +66,17 @@
   // J
   // K
   // L
+  {
+    "name": "LegacyDoc AI",
+    "description": "A VS Code extension that generates AI code audit reports, documentation, and Mermaid architecture maps from local workspaces.",
+    "url": "https://www.romanticode.com/legacydoc-ai/",
+    "icon_url": "https://www.romanticode.com/images/legacydoc-icon-512.png",
+    "tags": [
+      "AI",
+      "VS Code",
+      "Documentation"
+    ]
+  },
   // M
   // N
   {

--- a/data/json/zh/tools/ide.jsonc
+++ b/data/json/zh/tools/ide.jsonc
@@ -66,6 +66,17 @@
   // J
   // K
   // L
+  {
+    "name": "LegacyDoc AI",
+    "description": "A VS Code extension that generates AI code audit reports, documentation, and Mermaid architecture maps from local workspaces.",
+    "url": "https://www.romanticode.com/legacydoc-ai/",
+    "icon_url": "https://www.romanticode.com/images/legacydoc-icon-512.png",
+    "tags": [
+      "AI",
+      "VS Code",
+      "Documentation"
+    ]
+  },
   // M
   // N
   {


### PR DESCRIPTION
## Summary
- Add LegacyDoc AI to the IDE tool category for English and Chinese locale data.
- Include the RomantiCode product URL, icon URL, and three development-focused tags.

## Checks
- JSONC parsed successfully for both updated files.
- Entries remain alphabetically sorted by tool name.
- Product URL and icon URL return HTTP 200.
- `pnpm run build` passed with existing upstream warnings only.
